### PR TITLE
Fix OTRS user group

### DIFF
--- a/UpdateGroupJson.py
+++ b/UpdateGroupJson.py
@@ -69,7 +69,7 @@ def sortkeys(key: str) -> str:
         "global-renamer": "GRe",
         "global-rollbacker": "GRb",
         "templateeditor": "TE",
-        "otrs-member": "OTRS",
+        "vrt-permissions": "OTRS",
         "steward": "S"
     }
     return sortkeyDict[key]
@@ -84,7 +84,7 @@ localGroups = ["abusefilter", "abusefilter-helper", "accountcreator",
                "interface-admin", "massmessage-sender", "oversight",
                "sysop", "templateeditor"]
 extraLocalGroups = ["autoreviewer", "patroller", "reviewer", "rollbacker"]
-globalGroups = ["otrs-member", "steward", "global-rollbacker"]
+globalGroups = ["vrt-permissions", "steward", "global-rollbacker"]
 metaGroups = ["global-renamer"]
 arbcomJson = pywikibot.Page(site, "User:AmoryBot/crathighlighter.js/arbcom.json").get()
 arbcom_members = json.loads(arbcomJson)


### PR DESCRIPTION
The OTRS user group was renamed to `vrt-permissions` after OTRS was renamed to "Volunteer Response Team". This change broke the updater, so this patch aims to resolve the problem.