### PR TITLE
Change "oversight" to "suppress" due to T112147

### DIFF
--- a/UpdateGroupJson.py
+++ b/UpdateGroupJson.py
@@ -54,7 +54,7 @@ def sortkeys(key: str) -> str:
         "arbcom": "ARB",
         "bureaucrat": "B",
         "checkuser": "CU",
-        "oversight": "CV",
+        "suppress": "CV",
         "interface-admin": "IA",
         "abusefilter": "EFM",
         "abusefilter-helper": "EFH",
@@ -81,7 +81,7 @@ combinedJsonDataPage = pywikibot.Page(site, "User:MDanielsBot/markAdmins-Data.js
 
 localGroups = ["abusefilter", "abusefilter-helper", "accountcreator",
                "bureaucrat", "checkuser", "extendedmover", "filemover",
-               "interface-admin", "massmessage-sender", "oversight",
+               "interface-admin", "massmessage-sender", "suppress",
                "sysop", "templateeditor"]
 extraLocalGroups = ["autoreviewer", "patroller", "reviewer", "rollbacker"]
 globalGroups = ["otrs-member", "steward", "global-rollbacker"]


### PR DESCRIPTION
See <https://phabricator.wikimedia.org/T112147>, a breaking change to the WMF's configuration of MediaWiki, changing all internal references to "oversight" to "suppress". This change is needed for detection of oversighters to work, as there are no longer any users with the group "oversight".